### PR TITLE
Set application name

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,6 +39,8 @@ function createWindow () {
   mainWindowState.manage(mainWindow);
 }
 
+app.setName('Harmony');
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', createWindow);


### PR DESCRIPTION
Added `app.setName('Harmony')` in main.js. Overrides default name 'Electron'. 