### PR TITLE
Fix MPRIS not showing artist

### DIFF
--- a/app/js/player.js
+++ b/app/js/player.js
@@ -113,7 +113,7 @@ function playTrack(track) {
       'mpris:artUrl': (track.artwork ? track.artwork : 'file://'+__dirname+'/img/blank_artwork.png'),
       'xesam:title': track.title,
       'xesam:album': track.album.name,
-      'xesam:artist': track.artist.name
+      'xesam:artist': [track.artist.name]
     };
     mprisPlayer.playbackStatus = 'Playing';
   }


### PR DESCRIPTION
The mpris-service node module somehow expects an object as artist. This fixes it.
I searched quite a while to find the fix for this issue, i found it looking at line 56 in: https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/blob/master/src/main/features/linux/mprisService.js

Issue: 
![mpris_not_working](https://cloud.githubusercontent.com/assets/12088060/18615178/160de848-7da0-11e6-849b-7fceed761f9c.png)

('Unbekannter Titel' is german for 'unknown title')

Solution:
![mpris_working](https://cloud.githubusercontent.com/assets/12088060/18615180/1c200fe0-7da0-11e6-9aa4-c88876343c97.png)

