### PR TITLE
Fix crash when adding section to already existent service

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -56,7 +56,7 @@ function renderPlaylists() {
     if (!settings[k].active) continue;
 
     for (cat of ["discover", "mymusic", "playlists"]) {
-      if (!window[k][cat] || !data[k]) continue;
+      if (!window[k][cat] || !data[k] || !data[k][cat]) continue;
 
       for (pl of data[k][cat]) {
 


### PR DESCRIPTION
Harmony crashes with 'cannot read property pl of undefined' when adding for example discover to a service.

P.S.: I'm trying to add I'm feeling lucky radio of googlepm to Harmony. I do not quite understand where the icons come from? For example the compass icon of spotify discover.