### PR TITLE
Rebuild native module (ll-keyboard-hook-win) on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "electron main.js",
     "buildOSX": "build --mac dmg zip",
     "buildLinux": "build --linux AppImage deb rpm tar.xz --x64 --ia32",
-    "buildWin": "build --win nsis zip --x64 --ia32"
+    "buildWin": "build --win nsis zip --x64 --ia32",
+    "electron-rebuild": "electron-rebuild --pre-gyp-fix --force --module_dir . -w ll-keyboard-hook-win -e node_modules/electron-prebuilt",
+    "postinstall": "npm run electron-rebuild"
   },
   "keywords": [
     "music",
@@ -21,7 +23,9 @@
     "spotify"
   ],
   "devDependencies": {
-    "electron-prebuilt": "1.4.0"
+    "electron-prebuilt": "1.4.0",
+    "electron-builder": "5.22.1",
+    "electron-rebuild": "^1.3.0"
   },
   "dependencies": {
     "configstore": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "buildOSX": "build --mac dmg zip",
     "buildLinux": "build --linux AppImage deb rpm tar.xz --x64 --ia32",
     "buildWin": "build --win nsis zip --x64 --ia32",
-    "electron-rebuild": "electron-rebuild --pre-gyp-fix --force --module_dir . -w ll-keyboard-hook-win -e node_modules/electron-prebuilt",
-    "postinstall": "npm run electron-rebuild"
+    "electron-rebuild": "electron-rebuild --pre-gyp-fix --force --module_dir . -w ll-keyboard-hook-win -e node_modules/electron-prebuilt"
   },
   "keywords": [
     "music",


### PR DESCRIPTION
My fix in version 0.4.2 for Windows keyboard shortcuts didn't work correctly as the build system did not run an `electron-rebuild`. This PR fixes problem with `ll-keyboard-hook-win` by rebuilding the module on dev installs and when distributing.
I tested building on my Windows 10 desktop extensively and it works well. Hopefully this fixes my previous pull request's issue. (#97)

referenced from:
https://github.com/todbot/electron-hid-toy/blob/master/package.json